### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Generally speaking, technical decisions should be made by consensus within openE
 
 * The Chair is the ultimate adjudicator if things break down.
 * The absolute majority rule can be used to override an obstructionist veto, but it is intended that in normal circumstances vetoers need to be convinced to withdraw their veto. We are trying to reach consensus.
-* Software components that at least two other software repositories under https://github.com/Open-EO depend on, must implement a review system for breaking changes (e.g. GitHub Pull Request Approvals) that require a certain number of approvals: 1 dependant requires 1 approval, more than 1 dependant requires 2 approvals.
+* Software components that at least two other software repositories under https://github.com/Open-EO depend on, must implement a review system for breaking changes (e.g. GitHub Pull Request Approvals) that require a certain number of approvals: 2 dependants require 1 approval, more than 2 dependants require 2 approvals.
 
 ## Committee Membership
 


### PR DESCRIPTION
There's an inconsistency.... it says two dependents are required for the review process, but then talks about "1" and "1 or more". So I changed it to "2" and "2 or more". We could also generally lower to one dependent, if you think that is better.